### PR TITLE
Add support for init system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine
-RUN apk add --no-cache krb5-server krb5 supervisor
+RUN apk add --no-cache krb5-server krb5 supervisor tini
 ADD supervisord.conf /etc/supervisord.conf
 ADD docker-entrypoint.sh /
 VOLUME /var/lib/krb5kdc
 EXPOSE 749 464 88
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
* Use docker adopted `tini` software as init system to catch and propagate signals