### PR TITLE
chore: Language fixes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,17 +2,17 @@
 
 
 if [ -z ${KRB5_REALM} ]; then
-    echo "No KRB5_REALM Provided. Exiting ..."
+    echo "No KRB5_REALM provided. Exiting ..."
     exit 1
 fi
 
 if [ -z ${KRB5_KDC} ]; then
-    echo "No KRB5_KDC Provided. Exting ..."
+    echo "No KRB5_KDC provided. Exiting ..."
     exit 1
 fi
 
 if [ -z ${KRB5_ADMINSERVER} ]; then
-    echo "KRB5_ADMINSERVER provided. Using ${KRB5_KDC} in place."
+    echo "No KRB5_ADMINSERVER provided; Using ${KRB5_KDC} instead."
     KRB5_ADMINSERVER=${KRB5_KDC}
 fi
 
@@ -36,15 +36,15 @@ EOT
 
 if [ ! -f "/var/lib/krb5kdc/principal" ]; then
 
-    echo "No Krb5 Database Found. Creating One with provided information"
+    echo "No Krb5 database found. Creating one now."
 
     if [ -z ${KRB5_PASS} ]; then
-        echo "No Password for kdb provided ... Creating One"
+        echo "No Password for kdb provided; Creating one."
         KRB5_PASS=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;`
         echo "Using Password ${KRB5_PASS}"
     fi
 
-    echo "Creating KDC Configuration"
+    echo "Creating KDC configuration"
 cat <<EOT > /var/lib/krb5kdc/kdc.conf
 [kdcdefaults]
     kdc_listen = 88
@@ -66,11 +66,11 @@ cat <<EOT > /var/lib/krb5kdc/kdc.conf
     default = FILE:/var/log/krb5lib.log
 EOT
 
-echo "Creating Default Policy - Admin Access to */admin"
+echo "Creating default policy - Admin access to */admin"
 echo "*/admin@${KRB5_REALM} *" > /var/lib/krb5kdc/kadm5.acl
 echo "*/service@${KRB5_REALM} aci" >> /var/lib/krb5kdc/kadm5.acl
 
-    echo "Creating Temp pass file"
+    echo "Creating temporary password file"
 cat <<EOT > /etc/krb5_pass
 ${KRB5_PASS}
 ${KRB5_PASS}
@@ -80,7 +80,7 @@ EOT
     kdb5_util create -r ${KRB5_REALM} < /etc/krb5_pass
     rm /etc/krb5_pass
 
-    echo "Creating Admin Account"
+    echo "Creating admin account"
     kadmin.local -q "addprinc -pw ${KRB5_PASS} admin/admin@${KRB5_REALM}"
 
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -39,7 +39,7 @@ if [ ! -f "/var/lib/krb5kdc/principal" ]; then
     echo "No Krb5 database found. Creating one now."
 
     if [ -z ${KRB5_PASS} ]; then
-        echo "No Password for kdb provided; Creating one."
+        echo "No Password for kdb provided; Creating one now."
         KRB5_PASS=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;`
         echo "Using Password ${KRB5_PASS}"
     fi


### PR DESCRIPTION
This started as a small tweak to the logging output to make it less ambiguous.  
Specifically, I've added the *No* that was missing in the `KRB5_ADMINSERVER` check, and replaced *in place* with *instead* as I feel that is more descriptive of what we're doing.

While doing that, I noticed a typo (*Exting* instead of *Exiting*) so I decided to go through all the logging output and make it consistent in wording and capitalization.

None of these changes impact any code, logging output only.